### PR TITLE
Swap the dead domain in the nested bulmex package too

### DIFF
--- a/bulmex/README.md
+++ b/bulmex/README.md
@@ -1,4 +1,4 @@
-[![Jappiejappie](https://img.shields.io/badge/blog-jappieklooster.nl-lightgrey?style=for-the-badge)](https://jappieklooster.nl)
+[![Jappiejappie](https://img.shields.io/badge/blog-jappie.me-lightgrey?style=for-the-badge)](https://jappie.me)
 [![Build status](https://img.shields.io/travis/jappeace/bulmex?style=for-the-badge)](https://travis-ci.org/jappeace/bulmex/builds/)
 [![Jappiejappie](https://img.shields.io/badge/discord-jappiejappie-black?logo=discord&style=for-the-badge)](https://discord.gg/Hp4agqy)
 
@@ -12,7 +12,7 @@ it for you!
 There are also some helper functions for common tasks.
 such as making server side rendering easier.
 Which is described in a related
-[blogpost](https://jappieklooster.nl/reflex-server-side-html-rendering.html).
+[blogpost](https://jappie.me/reflex-server-side-html-rendering.html).
 
 ## Reflex
 - core: https://hackage.haskell.org/package/reflex

--- a/bulmex/bulmex.cabal
+++ b/bulmex/bulmex.cabal
@@ -8,7 +8,7 @@ cabal-version:  >= 1.10
 name:           bulmex
 version:        4.0.0
 synopsis:       Reflex infused with bulma (css)
-description:    Bulma is a pure CSS framework. Because of that it can be easily used with reflex. This library realizes that combination. Bulma already provided styling for a [modal](https://bulma.io/documentation/components/modal/), we just [implemented](https://hackage.haskell.org/package/bulmex/docs/Reflex-Bulmex-Modal.html) it for you! There are also some helper functions for common tasks. such as making server side rendering easier. Which is described in a related [blogpost](https://jappieklooster.nl/reflex-server-side-html-rendering.html).
+description:    Bulma is a pure CSS framework. Because of that it can be easily used with reflex. This library realizes that combination. Bulma already provided styling for a [modal](https://bulma.io/documentation/components/modal/), we just [implemented](https://hackage.haskell.org/package/bulmex/docs/Reflex-Bulmex-Modal.html) it for you! There are also some helper functions for common tasks. such as making server side rendering easier. Which is described in a related [blogpost](https://jappie.me/reflex-server-side-html-rendering.html).
 category:       Web
 homepage:       https://github.com/jappeace/bulmex#readme
 bug-reports:    https://github.com/jappeace/bulmex/issues

--- a/bulmex/package.yaml
+++ b/bulmex/package.yaml
@@ -20,7 +20,7 @@ description: Bulma is a pure CSS framework. Because of that it can be easily use
             There are also some helper functions for common tasks.
             such as making server side rendering easier.
             Which is described in a related
-            [blogpost](https://jappieklooster.nl/reflex-server-side-html-rendering.html).
+            [blogpost](https://jappie.me/reflex-server-side-html-rendering.html).
 
 ghc-options: -Wall -Wcompat -Wincomplete-uni-patterns -Widentities
 

--- a/bulmex/src/Reflex/Bulmex/Html.hs
+++ b/bulmex/src/Reflex/Bulmex/Html.hs
@@ -8,7 +8,7 @@
 -- | A root for an app,
 --   usefull for server side html rendering.
 --   has a neat api for the head tag, use this if that api suits your needs.
---   For more info see blogpost: https://jappieklooster.nl/reflex-server-side-html-rendering.html
+--   For more info see blogpost: https://jappie.me/reflex-server-side-html-rendering.html
 module Reflex.Bulmex.Html
   ( htmlWidget
   -- * Head tag stuff


### PR DESCRIPTION
Follow-up to #3, which covered the root README before I noticed the package subdirectory: the nested README badge, the blogpost links in package.yaml and the generated cabal description, and a Haddock comment all still pointed at jappieklooster.nl. The maintainer email is untouched, and the blogpost path resolves on jappie.me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017npGt8SoJaNtNCiu96uCrE